### PR TITLE
v1.3.0: Fix test errors not appending to test case output

### DIFF
--- a/bin/junit-bark.js
+++ b/bin/junit-bark.js
@@ -16,6 +16,10 @@ const resultRegex = new RegExp(/^[not]*\s*ok \d+ (.+)$/m);
     let currentSuite
     let currentSuiteName
     let stdOut = ""
+    let lastTestCase
+    let lastTestCaseStdOut
+    let lastTestCaseFailed = false
+    let readingErrorBlock = false
 
     tapLines.forEach(tapLine => {
         tapLine = `${tapLine}\n`
@@ -37,7 +41,7 @@ const resultRegex = new RegExp(/^[not]*\s*ok \d+ (.+)$/m);
         if (type === "comment") {
             // test suite
 
-            if (tapLine.includes("# FIXTURE ")) {
+            if (tapLine.startsWith("# FIXTURE ")) {
                 // strip prefix and newline from comment to get suite name
                 currentSuiteName = tapLine.replace("# FIXTURE ", "").replace(/\n/, "")
 
@@ -46,23 +50,59 @@ const resultRegex = new RegExp(/^[not]*\s*ok \d+ (.+)$/m);
         }
         else if (type === "extra") {
             // test case output
-
             stdOut += tapLine
+
+            if (
+              // the last test case failed and tap line is the start of an error block
+              // OR we are currently reading an error block
+              (lastTestCase && lastTestCaseFailed && tapLine.startsWith(" ---"))
+              || readingErrorBlock
+            ) {
+                if (!readingErrorBlock) {
+                    // start of error block after failed test
+                    readingErrorBlock = true
+                } else if (readingErrorBlock && tapLine.startsWith(" ...")) {
+                    // end of error block
+                    readingErrorBlock = false
+                }
+
+                // append to last test output and remove from current test
+                lastTestCaseStdOut += tapLine
+                stdOut = ""
+
+                if (!readingErrorBlock) {
+                    // flush standard out when error block has been read
+                    lastTestCase.standardOutput(lastTestCaseStdOut)
+                }
+            }
         } else if (type === "result") {
             // test case result
-
             let testCase = currentSuite.testCase()
                 .className(currentSuiteName)
                 .name(name)
-                .standardOutput(stdOut)
 
-            if (!ok) {
+            lastTestCase = testCase
+            lastTestCaseStdOut = stdOut
+            lastTestCaseFailed = ok
+            readingErrorBlock = false
+
+            if (ok) {
+                // test passed, no error expected so flush output now
+                testCase.standardOutput(stdOut)
+            } else {
                 testCase.failure()
+
+                lastTestCaseFailed = true
             }
 
             stdOut = ""
         }
     });
+
+    if (lastTestCaseFailed && stdOut === "") {
+        // no error block after last test, flush standard out
+        lastTestCase.standardOutput(lastTestCaseStdOut)
+    }
 
     // write to temp file because crappy API ¯\_(ツ)_/¯
     junitBuilder.writeTo(outputFile.name)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "junit-bark",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "JUnit XML reporter for Alsatian",
   "main": "bin/junit-bark.js",
   "bin": {
@@ -11,7 +11,9 @@
     "LICENSE",
     "bin/junit-bark.js"
   ],
-  "scripts": {},
+  "scripts": {
+    "test": "cd test && ./test.sh"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/djfdyuruiry/junit-bark.git"

--- a/test/output.tap
+++ b/test/output.tap
@@ -1,0 +1,29 @@
+TAP version 13
+1..4
+# FIXTURE Some fixture
+I am some std out
+isn't life wonderful
+ok 1 Some test that passes
+Even more std out
+not ok 2 Some test that fails
+ ---
+ message: Expected values to be equal
+ severity: fail
+ data:
+   got: 'true'
+   expect: 'false'
+   details:
+     diff: "\e[31mfals\e[39m\e[32mtru\e[39me"
+ ...
+ok 3 Some other test that passes
+some text for the last test
+not ok 4 A test at the end that fails
+ ---
+ message: Expected values to be fun
+ severity: fail
+ data:
+   got: 'true'
+   expect: 'false'
+   details:
+     diff: "\e[31mfals\e[39m\e[32mtru\e[39me"
+ ...

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+
+cat output.tap | ../bin/junit-bark.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,9 +36,9 @@ get-stdin@^7.0.0:
   integrity sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==
 
 glob@^7.1.3:
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
-  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"


### PR DESCRIPTION
- Capturing error blocks for failed tests
- Allowing TAP version line to be on any line in the output
- Capturing random output before TAP version in first test result